### PR TITLE
Avoid `caller` unless necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - An issue where Spans would not get Stacktraces attached ([#282](https://github.com/elastic/apm-agent-ruby/pull/282))
+- Skip `caller` unless needed ([#287](https://github.com/elastic/apm-agent-ruby/pull/283))
 
 ## 2.1.2 (2018-12-07)
 

--- a/lib/elastic_apm.rb
+++ b/lib/elastic_apm.rb
@@ -225,9 +225,13 @@ module ElasticAPM # rubocop:disable Metrics/ModuleLength
         name,
         type,
         context: context,
-        backtrace: include_stacktrace ? caller : nil,
         trace_context: trace_context
-      )
+      ).tap do |span|
+        break unless span && include_stacktrace
+        break unless agent.config.span_frames_min_duration?
+
+        span.original_backtrace ||= caller
+      end
     end
 
     # Ends the current span

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -241,6 +241,10 @@ module ElasticAPM
       @span_frames_min_duration_us = duration * 1_000_000
     end
 
+    def span_frames_min_duration?
+      span_frames_min_duration != 0
+    end
+
     DEPRECATED_OPTIONS = %i[
       compression_level=
       compression_minimum_size=

--- a/lib/elastic_apm/instrumenter.rb
+++ b/lib/elastic_apm/instrumenter.rb
@@ -160,7 +160,7 @@ module ElasticAPM
         trace_context: trace_context || parent.trace_context.child
       )
 
-      if backtrace && span_frames_min_duration?
+      if backtrace && config.span_frames_min_duration?
         span.original_backtrace = backtrace
       end
 
@@ -210,10 +210,6 @@ module ElasticAPM
 
     def random_sample?
       rand <= config.transaction_sample_rate
-    end
-
-    def span_frames_min_duration?
-      config.span_frames_min_duration != 0
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/elastic_apm/span.rb
+++ b/lib/elastic_apm/span.rb
@@ -33,8 +33,7 @@ module ElasticAPM
     # rubocop:enable Metrics/ParameterLists
 
     attr_accessor :name, :type, :original_backtrace, :parent_id, :trace_context
-    attr_reader :context, :stacktrace, :duration,
-      :timestamp, :transaction_id
+    attr_reader :context, :stacktrace, :duration, :timestamp, :transaction_id
 
     def id
       trace_context&.span_id
@@ -59,9 +58,7 @@ module ElasticAPM
     def done(end_time: Util.micros)
       stop end_time
 
-      if should_build_stacktrace?
-        build_stacktrace
-      end
+      build_stacktrace! if should_build_stacktrace?
 
       self
     end
@@ -89,13 +86,13 @@ module ElasticAPM
 
     private
 
-    def should_build_stacktrace?
-      @stacktrace_builder && original_backtrace && long_enough_for_stacktrace?
+    def build_stacktrace!
+      @stacktrace = @stacktrace_builder.build(original_backtrace, type: :span)
+      self.original_backtrace = nil # release original
     end
 
-    def build_stacktrace
-      @stacktrace = @stacktrace_builder.build(original_backtrace, type: :span)
-      self.original_backtrace = nil # release it
+    def should_build_stacktrace?
+      @stacktrace_builder && original_backtrace && long_enough_for_stacktrace?
     end
 
     def long_enough_for_stacktrace?

--- a/spec/elastic_apm/instrumenter_spec.rb
+++ b/spec/elastic_apm/instrumenter_spec.rb
@@ -130,20 +130,20 @@ module ElasticAPM
           expect(subject.current_span).to eq span
         end
 
+        context 'with a backtrace' do
+          it 'saves original backtrace for later' do
+            backtrace = caller
+            span = subject.start_span 'Span', backtrace: backtrace
+            expect(span.original_backtrace).to eq backtrace
+          end
+        end
+
         context 'inside another span' do
           it 'sets current span as parent' do
             parent = subject.start_span 'Level 1'
             child = subject.start_span 'Level 2'
 
             expect(child.parent_id).to be parent.id
-          end
-        end
-
-        context 'with a backtrace' do
-          it 'saves original backtrace for later' do
-            backtrace = caller
-            span = subject.start_span 'Span', backtrace: backtrace
-            expect(span.original_backtrace).to eq backtrace
           end
         end
 


### PR DESCRIPTION
* Only call `caller` when transaction is sampled

`caller` is very slow on JRuby. I couldn't find a way around it, so this
changes it to only be called when a transaction/span is being sampled.
Previously, setting `transaction_sample_rate` didn't improve performance
for our JRuby app.

* Build stacktrace on worker thread

I didn't see a reason for stacktrace building/parsing to run when
generating a span on the main thread. This moves it be being generated
lazily in a worker.

* Keep old backtrace api

* Update changelog